### PR TITLE
couple of mini bug fixes

### DIFF
--- a/clients/cpp/Telecmd.h
+++ b/clients/cpp/Telecmd.h
@@ -23,7 +23,7 @@
 #define TELECMD_INPUT_BUFFER_SIZE 1024
 class Telecmd {
 public:
-    Telecmd(std::string address) : address_(address)
+    Telecmd(std::string address) : sockfd_(-1), sockfdOut_(-1), address_(address)
     {
         #ifdef TELECMD_DISABLE
             return ;
@@ -37,9 +37,9 @@ public:
         serv_.sin_port = htons(47268);
 
         // Set addr reuse
-        uint8_t yes = 1;
-        setsockopt(sockfd_, SOL_SOCKET, SO_REUSEADDR, (char*) &yes, sizeof(yes));
-        setsockopt(sockfd_, SOL_SOCKET, SO_REUSEPORT, (const char*)&yes, sizeof(yes));
+        int yes = 1;
+        setsockopt(sockfd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+        setsockopt(sockfd_, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes));
 
         // Set socket timeout
         struct timeval timeout;
@@ -61,7 +61,13 @@ public:
             std::cout << "Telecmd init failed" <<std::endl;
         }
     };
-    ~Telecmd() = default;
+    ~Telecmd() {
+        #ifdef TELECMD_DISABLE
+            return;
+        #endif
+        if (sockfd_ >= 0)    { (void)::close(sockfd_);    sockfd_    = -1; }
+        if (sockfdOut_ >= 0) { (void)::close(sockfdOut_); sockfdOut_ = -1; }
+    }
 
     // Static localhost instance
     static Telecmd &localhost() {static Telecmd telecmd("127.0.0.1"); return telecmd;}
@@ -97,7 +103,7 @@ private:
         {
             cmdList += registeredCmd.first + "|";
         }
-        sendto(sockfdOut_, cmdList.c_str(), cmdList.size(), MSG_CONFIRM, (const struct sockaddr *) &servOut_, sizeof(servOut_));
+        sendto(sockfdOut_, cmdList.c_str(), cmdList.size(), 0, (const struct sockaddr *) &servOut_, sizeof(servOut_));
     }
 
     void parseFunctionCall(std::string const& cmd) {

--- a/clients/cpp/Teleplot.h
+++ b/clients/cpp/Teleplot.h
@@ -340,15 +340,7 @@ private:
     }
 
     void emit(std::string const& data){
-        ssize_t sent = sendto(sockfd_, data.c_str(), data.size(), 0, (struct sockaddr *)&serv_, sizeof(serv_));
-        if (sent < 0) {
-            int err = errno;
-#if EAGAIN == EWOULDBLOCK
-            if (err == EAGAIN) return;
-#else
-            if (err == EAGAIN || err == EWOULDBLOCK) return;
-#endif
-        }
+        (void) sendto(sockfd_, data.c_str(), data.size(), 0, (struct sockaddr *)&serv_, sizeof(serv_));
     }
 
     #ifdef TELEPLOT_USE_BUFFERING

--- a/clients/cpp/Teleplot.h
+++ b/clients/cpp/Teleplot.h
@@ -5,15 +5,17 @@
 #define TELEPLOT_H
 
 #include <iostream>
-#include <iomanip> 
+#include <iomanip>
 #include <arpa/inet.h>
+#include <cerrno>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sstream> 
+#include <sstream>
 #include <map>
 #include <chrono>
 
@@ -199,7 +201,8 @@ private:
 class Teleplot {
 public:
     Teleplot(std::string address, unsigned int port=47269, unsigned int bufferingFrequencyHz = 30)
-        : address_(address)
+        : sockfd_(-1)
+        , address_(address)
         , bufferingFrequencyHz_(bufferingFrequencyHz)
     {
         #ifdef TELEPLOT_DISABLE
@@ -210,8 +213,17 @@ public:
         serv_.sin_family = AF_INET;
         serv_.sin_port = htons(port);
         serv_.sin_addr.s_addr = inet_addr(address_.c_str());
+        if (sockfd_ >= 0) {
+            int fl = fcntl(sockfd_, F_GETFL, 0);
+            if (fl >= 0) (void)fcntl(sockfd_, F_SETFL, fl | O_NONBLOCK);
+        }
     };
-    ~Teleplot() = default;
+    ~Teleplot() {
+        #ifdef TELEPLOT_DISABLE
+            return;
+        #endif
+        if (sockfd_ >= 0) { (void)::close(sockfd_); sockfd_ = -1; }
+    }
 
     // Static localhost instance
     static Teleplot &localhost() {static Teleplot teleplot("127.0.0.1"); return teleplot;}
@@ -258,8 +270,8 @@ public:
         if(updateTimestampsUs_.find(key) == updateTimestampsUs_.end()) {
             return true;
         }
-        int64_t elasped = nowUs - updateTimestampsUs_[key];
-        if(elasped >= static_cast<int64_t>(1e6/frequency)) {
+        int64_t elapsed = nowUs - updateTimestampsUs_[key];
+        if(elapsed >= static_cast<int64_t>(1e6/frequency)) {
             return true;
         }
         return false;
@@ -328,7 +340,15 @@ private:
     }
 
     void emit(std::string const& data){
-        (void) sendto(sockfd_, data.c_str(), data.size(), 0, (struct sockaddr *)&serv_, sizeof(serv_));
+        ssize_t sent = sendto(sockfd_, data.c_str(), data.size(), 0, (struct sockaddr *)&serv_, sizeof(serv_));
+        if (sent < 0) {
+            int err = errno;
+#if EAGAIN == EWOULDBLOCK
+            if (err == EAGAIN) return;
+#else
+            if (err == EAGAIN || err == EWOULDBLOCK) return;
+#endif
+        }
     }
 
     #ifdef TELEPLOT_USE_BUFFERING
@@ -353,8 +373,8 @@ private:
         void flushBuffer(std::string const& key, std::string const& flags, std::string unit, bool force, bool is3D = false) {
             // Flush the buffer if the frequency is reached
             int64_t nowUs = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
-            int64_t elasped = nowUs - bufferingFlushTimestampsUs_[key];
-            if(force || elasped >= static_cast<int64_t>(1e6/bufferingFrequencyHz_)) {
+            int64_t elapsed = nowUs - bufferingFlushTimestampsUs_[key];
+            if(force || elapsed >= static_cast<int64_t>(1e6/bufferingFrequencyHz_)) {
                 emit(formatPacket(key, bufferingMap_[key], flags, unit, is3D));
                 bufferingMap_[key].clear();
                 bufferingFlushTimestampsUs_[key] = nowUs;
@@ -373,7 +393,6 @@ private:
     std::string address_;
     sockaddr_in serv_;
     unsigned int bufferingFrequencyHz_;
-    int64_t lastBufferingFlushTimestampUs_=0;
 };
 
 #endif


### PR DESCRIPTION
- Destroy `sockfd_` on destruction
- init `sockfd_` to `-1` to avoid garbage fd when `TELEPLOT_DISABLE`
- set `O_NONBLOCK` after socket creation to avoid stalling
- remove dead `lastBufferingFlushTimestampUs_` member
- fix typos